### PR TITLE
feat: Project 추가 페이지 UI 및 라우팅 구현

### DIFF
--- a/src/api/projects.api.ts
+++ b/src/api/projects.api.ts
@@ -1,0 +1,25 @@
+import axios from 'axios';
+import {
+  type CreateProjectRequestDto,
+  type CreateProjectResponseDto,
+  type GetProjectResponseDto,
+} from '../types/dto/projects.dto';
+
+const API_BASE = process.env.REACT_APP_API_BASE || '';
+
+export const api = axios.create({
+  baseURL: API_BASE,
+  headers: { 'Content-Type': 'application/json' },
+});
+
+export async function createProject(body: CreateProjectRequestDto) {
+  const { data } = await api.post<CreateProjectResponseDto>('/projects', body);
+  return data;
+}
+
+export async function getProject(projectId: string | number) {
+  const { data } = await api.get<GetProjectResponseDto>(
+    `/projects/${projectId}`
+  );
+  return data;
+}

--- a/src/pages/project-list-page/index.css.tsx
+++ b/src/pages/project-list-page/index.css.tsx
@@ -1,0 +1,118 @@
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+
+export const Page = styled.div`
+  width: 100vw;
+  min-height: 100vh;
+  background: #fafafa;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const Header = styled.header`
+  padding: 16px 24px;
+  background: #fff;
+  border-bottom: 1px solid #e5e5e5;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const Title = styled.h1`
+  font-size: 20px;
+  font-weight: 600;
+`;
+
+export const Main = styled.main`
+  flex: 1;
+  padding: 32px 24px;
+  width: 100%;
+`;
+
+export const SectionTitle = styled.h2`
+  font-size: 18px;
+  font-weight: 500;
+  margin-bottom: 12px;
+`;
+
+export const Row = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+`;
+
+export const CardBase = styled(Link)`
+  flex: 1 1 calc((100% - 16px) / 2);
+  max-width: calc((100% - 16px) / 2);
+
+  @media (min-width: 1024px) {
+    flex-basis: calc((100% - 32px) / 3);
+    max-width: calc((100% - 32px) / 3);
+  }
+  @media (min-width: 1440px) {
+    flex-basis: calc((100% - 48px) / 4);
+    max-width: calc((100% - 48px) / 4);
+  }
+
+  aspect-ratio: 4 / 3;
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  transition: box-shadow 0.15s ease;
+  text-decoration: none;
+  color: inherit;
+
+  &:hover {
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
+  }
+`;
+
+export const CreateCard = styled(CardBase)`
+  border-style: dashed;
+  border-width: 2px;
+  border-color: #d4d4d4;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    border-color: #a3a3a3;
+  }
+`;
+
+export const CreateButton = styled.button`
+  padding: 8px 12px;
+  font-size: 14px;
+  background: #000;
+  color: #fff;
+  border-radius: 10px;
+  border: 1px solid #000;
+  cursor: pointer;
+  &:hover {
+    background: #222;
+  }
+`;
+
+export const CardTitle = styled.h3`
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+`;
+
+export const CardDate = styled.div`
+  margin-top: 8px;
+  font-size: 13px;
+  color: #737373;
+`;
+
+export const EmptyText = styled.p`
+  margin-top: 12px;
+  font-size: 14px;
+  color: #737373;
+`;

--- a/src/pages/project-list-page/index.tsx
+++ b/src/pages/project-list-page/index.tsx
@@ -1,0 +1,129 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Page,
+  Header,
+  Title,
+  Main,
+  SectionTitle,
+  Row,
+  CardBase,
+  CreateCard,
+  CreateButton,
+  CardTitle,
+  CardDate,
+  EmptyText,
+} from './index.css';
+import { type ProjectDto } from '../../types/dto/projects.dto';
+
+function ymd(date: string | Date) {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  return new Date(d.getTime() - d.getTimezoneOffset() * 60000)
+    .toISOString()
+    .slice(0, 10);
+}
+
+export const ProjectListPage = () => {
+  const [projects, setProjects] = useState<ProjectDto[]>([
+    // 프로젝트 더미데이터
+    {
+      id: 101,
+      authorEmail: 'dev@example.com',
+      projectName: '프로젝트 A 기획',
+      projectCode: 'PA-2025-01',
+      projectKeyword: ['기획', '요구사항'],
+      links: ['https://github.com/org/repo-a'],
+      createdAt: '2025-08-01T09:00:00Z',
+      updatedAt: '2025-08-01T09:00:00Z',
+    },
+    {
+      id: 102,
+      authorEmail: 'ux@example.com',
+      projectName: '프로젝트 B 디자인 시안',
+      projectCode: 'PB-2025-02',
+      projectKeyword: ['디자인', '시안'],
+      links: ['https://jira.example.com/browse/DESIGN-12'],
+      createdAt: '2025-08-05T10:30:00Z',
+      updatedAt: '2025-08-05T10:30:00Z',
+    },
+    {
+      id: 103,
+      authorEmail: 'fe@example.com',
+      projectName: '프로젝트 C 개발 일정',
+      projectCode: 'PC-2025-03',
+      projectKeyword: ['개발', '일정'],
+      links: ['https://slack.com/app_redirect?channel=C123456'],
+      createdAt: '2025-08-09T12:00:00Z',
+      updatedAt: '2025-08-09T12:00:00Z',
+    },
+  ]);
+
+  const navigate = useNavigate();
+
+  const onCreated = ({ project }: { project: ProjectDto }) => {
+    setProjects(prev => [project, ...prev]);
+    navigate(`/projects/${project.id}`);
+  };
+
+  return (
+    <Page>
+      <Header>
+        <Title>Projects</Title>
+        <CreateButton onClick={() => navigate(`/projects/new`)}>
+          새 프로젝트 만들기
+        </CreateButton>
+      </Header>
+
+      <Main>
+        <SectionTitle>최근 프로젝트</SectionTitle>
+        <Row>
+          <CreateCard
+            to="#"
+            onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
+              e.preventDefault();
+              navigate(`/projects/new`);
+            }}
+          >
+            <div style={{ textAlign: 'center' }}>
+              <div
+                style={{
+                  margin: '0 auto 8px',
+                  height: 48,
+                  width: 48,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  borderRadius: 9999,
+                  background: '#f5f5f5',
+                  color: '#525252',
+                  fontSize: 24,
+                  fontWeight: 600,
+                }}
+              >
+                +
+              </div>
+              <div style={{ color: '#525252' }}>새 프로젝트 만들기</div>
+            </div>
+          </CreateCard>
+
+          {projects.map(p => (
+            <CardBase key={p.id} to={`/projects/${p.id}`}>
+              <div style={{ flex: 1 }}>
+                <CardTitle>
+                  {p.projectName} ({p.projectCode})
+                </CardTitle>
+              </div>
+              <CardDate>{ymd(p.createdAt)}</CardDate>
+            </CardBase>
+          ))}
+        </Row>
+
+        {projects.length === 0 && (
+          <EmptyText>
+            아직 프로젝트가 없습니다. ‘새 프로젝트 만들기’를 눌러 생성해 보세요.
+          </EmptyText>
+        )}
+      </Main>
+    </Page>
+  );
+};

--- a/src/types/dto/projects.dto.ts
+++ b/src/types/dto/projects.dto.ts
@@ -1,0 +1,39 @@
+export type ProjectDto = {
+  id: number;
+  authorEmail: string;
+  projectName: string;
+  projectCode: string;
+  projectKeyword?: string[];
+  links?: string[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type LinkItemDto = {
+  itemId: number;
+  materialType: string;
+  link: string;
+  title: string;
+  body: string;
+  isFixed: 'true' | 'false';
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type CreateProjectRequestDto = {
+  authorEmail: string;
+  projectName: string;
+  projectCode: string;
+  projectKeyword?: string[];
+  links?: string[];
+};
+
+export type CreateProjectResponseDto = {
+  project: ProjectDto;
+  links: LinkItemDto[];
+};
+
+export type GetProjectResponseDto = {
+  project: ProjectDto;
+  links: LinkItemDto[];
+};


### PR DESCRIPTION
#### **📝 개요 (Overview)**

이번 PR에서는 프로젝트 생성 페이지의 UI를 구성하고 라우팅을 구현하였습니다. 또한 프로젝트 생성 및 조회에 필요한 타입과 API를 정리하였습니다

---

#### **✨ 주요 변경 내용 (Key Changes)**

* **1. 반응형 UI로 화면의 너비에 따라 4개,3개,2개의 프로젝트가 배치되도록 하였습니다**
* **2. DTO를 별도의 폴더에 분리하여 정리하였습니다**
* **3. 프로젝트 생성 및 조회를 위한 API 통신을 구현하였습니다**

---

#### **스크린샷**
<img width="1840" height="1191" alt="스크린샷 2025-08-09 오후 5 43 33" src="https://github.com/user-attachments/assets/787755c1-d68c-4275-9db1-3258b52afbfa" />

<img width="1840" height="1191" alt="스크린샷 2025-08-09 오후 5 44 01" src="https://github.com/user-attachments/assets/2d2d197a-d3e8-47c8-ac61-de750367feab" />

<img width="1840" height="1191" alt="스크린샷 2025-08-09 오후 5 44 01" src="https://github.com/user-attachments/assets/4b2f6640-10ad-4539-baca-0fd9e5ffd97f" />



