### PR TITLE
feat: Project 생성을 위한 Modal창 구현 및 Projects 조회, 생성 API 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
-import logo from './logo.svg';
 import './App.css';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { ProjectListPage } from './pages/project-list-page';
 import ProjectsPage from './pages/projects';
 
 function App() {
@@ -9,7 +8,7 @@ function App() {
     <div className="App">
       <BrowserRouter>
         <Routes>
-          <Route path="/" />
+          <Route path="/" element={<ProjectListPage />} />
           <Route path="/projects" element={<ProjectsPage />} />
         </Routes>
       </BrowserRouter>

--- a/src/api/projects.api.ts
+++ b/src/api/projects.api.ts
@@ -1,16 +1,107 @@
 import axios from 'axios';
+
 import {
+  type ProjectDto,
   type CreateProjectRequestDto,
   type CreateProjectResponseDto,
   type GetProjectResponseDto,
 } from '../types/dto/projects.dto';
 
-const API_BASE = process.env.REACT_APP_API_BASE || '';
+const API_BASE = 'http://localhost:8000/api';
 
 export const api = axios.create({
   baseURL: API_BASE,
   headers: { 'Content-Type': 'application/json' },
 });
+
+type ProjectListResponse = {
+  count: number;
+  next: null;
+  previous: null;
+  results: Array<{
+    id: number;
+    author_email: string;
+    project_name: string;
+    project_code: string;
+    project_keyword: string;
+    created_at: string;
+    updated_at: string;
+  }>;
+};
+
+// GET /api/projects/
+export async function listProjects(): Promise<ProjectDto[]> {
+  const { data } = await api.get<ProjectListResponse>('/projects/');
+  return (data.results || []).map(p => ({
+    id: p.id,
+    authorEmail: p.author_email,
+    projectName: p.project_name,
+    projectCode: p.project_code,
+    projectKeyword:
+      p.project_keyword
+        ?.split(',')
+        .map(s => s.trim())
+        .filter(Boolean) || [],
+    createdAt: p.created_at,
+    updatedAt: p.updated_at,
+  }));
+}
+
+// POST /api/projects/
+export async function createProjectApi(body: {
+  author_email: string;
+  project_name: string;
+  project_code: string;
+  project_keyword: string;
+}) {
+  const { data } = await api.post('/projects/', body);
+
+  return data;
+}
+
+// POST /api/materials/
+export async function createMaterialApi(body: {
+  material_type: string;
+  material_link: string;
+  project: number;
+}) {
+  const { data } = await api.post('/materials/', body);
+  return data;
+}
+
+// POST /api/projects/{id}/create_items_from_external_matches_by_code/
+export async function createItemsByCodeApi(
+  projectId: number,
+  body: {
+    author_email: string;
+    project_name: string;
+    project_code: string;
+    project_keyword?: string;
+  }
+) {
+  const { data } = await api.post(
+    `/projects/${projectId}/create_items_from_external_matches_by_code/`,
+    body
+  );
+  return data;
+}
+
+// POST /api/projects/{id}/create_items_from_external_matches_by_keyword/
+export async function createItemsByKeywordApi(
+  projectId: number,
+  body: {
+    author_email: string;
+    project_name: string;
+    project_code: string;
+    project_keyword?: string;
+  }
+) {
+  const { data } = await api.post(
+    `/projects/${projectId}/create_items_from_external_matches_by_keyword/`,
+    body
+  );
+  return data;
+}
 
 export async function createProject(body: CreateProjectRequestDto) {
   const { data } = await api.post<CreateProjectResponseDto>('/projects', body);

--- a/src/components/create-project-modal/index.css.tsx
+++ b/src/components/create-project-modal/index.css.tsx
@@ -1,0 +1,92 @@
+import styled from 'styled-components';
+
+export const Title = styled.h1`
+  font-size: 20px;
+  font-weight: 600;
+`;
+
+export const ModalBg = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const ModalCard = styled.div`
+  width: 560px;
+  max-width: calc(100% - 32px);
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  padding: 20px;
+  display: grid;
+  gap: 12px;
+`;
+
+export const Field = styled.div`
+  display: grid;
+  gap: 6px;
+`;
+
+export const Label = styled.label`
+  text-align: left;
+  font-size: 13px;
+  color: #404040;
+  font-weight: 500;
+`;
+
+export const Input = styled.input`
+  border: 1px solid #e5e5e5;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 14px;
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px #00000020;
+  }
+`;
+
+export const Textarea = styled.textarea`
+  border: 1px solid #e5e5e5;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 14px;
+  min-height: 72px;
+  resize: none;
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px #00000020;
+  }
+`;
+
+export const ModalActions = styled.div`
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 4px;
+`;
+
+export const GhostBtn = styled.button`
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  cursor: pointer;
+  &:hover {
+    background: #f5f5f5;
+  }
+`;
+
+export const PrimaryBtn = styled.button`
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: #000;
+  color: #fff;
+  border: 1px solid #000;
+  cursor: pointer;
+  &:hover {
+    background: #222;
+  }
+`;

--- a/src/components/create-project-modal/index.tsx
+++ b/src/components/create-project-modal/index.tsx
@@ -1,0 +1,277 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import {
+  Title,
+  ModalBg,
+  ModalCard,
+  Field,
+  Label,
+  Input,
+  Textarea,
+  ModalActions,
+  GhostBtn,
+  PrimaryBtn,
+} from './index.css';
+
+import {
+  createProjectApi,
+  createMaterialApi,
+  createItemsByCodeApi,
+  createItemsByKeywordApi,
+} from '../../api/projects.api';
+
+import {
+  type CreateProjectRequestDto,
+  type ProjectDto,
+} from '../../types/dto/projects.dto';
+
+type CreateMaterialPayload = {
+  material_type: 'github' | 'jira' | 'slack' | 'web' | string;
+  material_link: string;
+  project: number;
+};
+
+type LinkItemForm = {
+  material_type: 'github' | 'jira' | 'slack' | 'web' | string;
+  material_link: string;
+};
+
+export function CreateProjectModal({
+  onClose,
+  onSuccess,
+}: {
+  onClose: () => void;
+  onSuccess: (created: { project: ProjectDto }) => void;
+}) {
+  const navigate = useNavigate();
+  const [authorEmail, setAuthorEmail] = useState('');
+  const [projectName, setProjectName] = useState('');
+  const [projectCode, setProjectCode] = useState('');
+  const [projectKeyword, setProjectKeyword] = useState('');
+  const [linkItems, setLinkItems] = useState<LinkItemForm[]>([
+    { material_type: 'github', material_link: '' },
+  ]);
+
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const parseCSV = (s: string) =>
+    s
+      .split(',')
+      .map(v => v.trim())
+      .filter(Boolean);
+
+  const addLinkItem = () => {
+    setLinkItems(prev => [
+      ...prev,
+      { material_type: 'web', material_link: '' },
+    ]);
+  };
+
+  const removeLinkItem = (idx: number) => {
+    setLinkItems(prev => prev.filter((_, i) => i !== idx));
+  };
+
+  const updateLinkItem = (idx: number, patch: Partial<LinkItemForm>) => {
+    setLinkItems(prev =>
+      prev.map((item, i) => (i === idx ? { ...item, ...patch } : item))
+    );
+  };
+
+  const submit = async () => {
+    setErr(null);
+
+    if (!authorEmail || !projectName || !projectCode) {
+      setErr('Email, 프로젝트명, 프로젝트 코드는 필수입니다.');
+      return;
+    }
+
+    // 링크 항목 유효성 체크(비어있는 항목은 제외)
+    const validLinkItems = linkItems
+      .map(i => ({
+        material_type: i.material_type?.trim(),
+        material_link: i.material_link?.trim(),
+      }))
+      .filter(i => i.material_link);
+
+    setLoading(true);
+    try {
+      // POST /api/projects/
+      const keywordString =
+        projectKeyword.trim().length > 0
+          ? parseCSV(projectKeyword).join(',')
+          : '';
+
+      const reqBody: any = {
+        author_email: authorEmail,
+        project_name: projectName,
+        project_code: projectCode,
+        project_keyword: keywordString || undefined,
+      };
+
+      const created = await createProjectApi(reqBody);
+      const projectId: number = created.id;
+
+      // POST /api/materials/
+      if (validLinkItems.length > 0) {
+        const materialPayloads: CreateMaterialPayload[] = validLinkItems.map(
+          item => ({
+            material_type:
+              item.material_type || inferMaterialType(item.material_link),
+            material_link: item.material_link,
+            project: projectId,
+          })
+        );
+
+        await Promise.all(
+          materialPayloads.map(payload => createMaterialApi(payload))
+        );
+      }
+
+      // POST /api/projects/{id}/create_items_from_external_matches_by_code/
+      // POST /api/projects/{id}/create_items_from_external_matches_by_keyword/
+      const triggerBody = {
+        author_email: authorEmail,
+        project_name: projectName,
+        project_code: projectCode,
+        project_keyword: keywordString || '',
+      };
+
+      await Promise.all([
+        createItemsByCodeApi(projectId, triggerBody),
+        createItemsByKeywordApi(projectId, triggerBody),
+      ]);
+
+      navigate(`/project/${projectId}`);
+    } catch (e: any) {
+      setErr(e?.message || '프로젝트 생성 실패');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ModalBg onClick={onClose}>
+      <ModalCard onClick={e => e.stopPropagation()}>
+        <Title style={{ fontSize: 18 }}>새 프로젝트 등록하기</Title>
+
+        <Field>
+          <Label>Email</Label>
+          <Input
+            placeholder="smilegate@example.com"
+            value={authorEmail}
+            onChange={e => setAuthorEmail(e.target.value)}
+          />
+        </Field>
+
+        <Field>
+          <Label>프로젝트명</Label>
+          <Input
+            value={projectName}
+            onChange={e => setProjectName(e.target.value)}
+          />
+        </Field>
+
+        <Field>
+          <Label>프로젝트 코드 (예: KT-2025-01)</Label>
+          <Input
+            value={projectCode}
+            onChange={e => setProjectCode(e.target.value)}
+          />
+        </Field>
+
+        <Field>
+          <Label>키워드 (쉼표로 구분)</Label>
+          <Input
+            placeholder="webrtc, 정산"
+            value={projectKeyword}
+            onChange={e => setProjectKeyword(e.target.value)}
+          />
+        </Field>
+
+        <Label>관련 링크</Label>
+        {linkItems.map((item, idx) => (
+          <div
+            key={idx}
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '160px 1fr auto',
+              gap: 8,
+              alignItems: 'center',
+              marginBottom: 8,
+            }}
+          >
+            <select
+              value={item.material_type}
+              onChange={e =>
+                updateLinkItem(idx, { material_type: e.target.value })
+              }
+              style={{
+                width: '100%',
+                border: '1px solid #e5e5e5',
+                borderRadius: 10,
+                padding: '10px 12px',
+                fontSize: 14,
+              }}
+            >
+              <option value="github">github</option>
+              <option value="jira">jira</option>
+              <option value="slack">slack</option>
+              <option value="web">web</option>
+            </select>
+
+            <Input
+              placeholder="https://github.com/org/repo"
+              value={item.material_link}
+              onChange={e =>
+                updateLinkItem(idx, { material_link: e.target.value })
+              }
+            />
+
+            <div>
+              <GhostBtn
+                onClick={() => removeLinkItem(idx)}
+                disabled={linkItems.length === 1}
+                title={linkItems.length === 1 ? '최소 1개 항목' : '삭제'}
+              >
+                삭제
+              </GhostBtn>
+            </div>
+          </div>
+        ))}
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            marginBottom: 8,
+          }}
+        >
+          <GhostBtn onClick={addLinkItem}>+ 링크 추가</GhostBtn>
+        </div>
+
+        {err && <div style={{ color: '#dc2626', fontSize: 13 }}>{err}</div>}
+
+        <ModalActions>
+          <GhostBtn onClick={onClose} disabled={loading}>
+            취소
+          </GhostBtn>
+          <PrimaryBtn onClick={submit} disabled={loading}>
+            {loading ? '생성 중...' : '생성'}
+          </PrimaryBtn>
+        </ModalActions>
+      </ModalCard>
+    </ModalBg>
+  );
+}
+
+function inferMaterialType(
+  url: string
+): 'github' | 'jira' | 'slack' | 'web' | string {
+  const u = url.toLowerCase();
+  if (u.includes('github.com')) return 'github';
+  if (u.includes('jira')) return 'jira';
+  if (u.includes('slack.com')) return 'slack';
+  return 'web';
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   font-family:

--- a/src/pages/project-list-page/index.css.tsx
+++ b/src/pages/project-list-page/index.css.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 export const Page = styled.div`
   width: 100vw;
   min-height: 100vh;
-  background: #fafafa;
+  background: #f0f0f0;
   display: flex;
   flex-direction: column;
 `;
@@ -25,7 +25,7 @@ export const Title = styled.h1`
 
 export const Main = styled.main`
   flex: 1;
-  padding: 32px 24px;
+  padding: 16px 24px;
   width: 100%;
 `;
 
@@ -44,6 +44,7 @@ export const Row = styled.div`
 export const CardBase = styled(Link)`
   flex: 1 1 calc((100% - 16px) / 2);
   max-width: calc((100% - 16px) / 2);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 
   @media (min-width: 1024px) {
     flex-basis: calc((100% - 32px) / 3);
@@ -76,6 +77,7 @@ export const CreateCard = styled(CardBase)`
   border-color: #d4d4d4;
   align-items: center;
   justify-content: center;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 
   &:hover {
     border-color: #a3a3a3;

--- a/src/pages/project-list-page/index.tsx
+++ b/src/pages/project-list-page/index.tsx
@@ -1,20 +1,20 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import Navbar from '../../components/navbar';
+
 import { useNavigate } from 'react-router-dom';
 import {
   Page,
-  Header,
-  Title,
   Main,
-  SectionTitle,
   Row,
   CardBase,
   CreateCard,
-  CreateButton,
   CardTitle,
   CardDate,
   EmptyText,
 } from './index.css';
 import { type ProjectDto } from '../../types/dto/projects.dto';
+import { listProjects } from '../../api/projects.api';
+import { CreateProjectModal } from '../../components/create-project-modal';
 
 function ymd(date: string | Date) {
   const d = typeof date === 'string' ? new Date(date) : date;
@@ -23,65 +23,74 @@ function ymd(date: string | Date) {
     .slice(0, 10);
 }
 
-export const ProjectListPage = () => {
-  const [projects, setProjects] = useState<ProjectDto[]>([
-    // 프로젝트 더미데이터
-    {
-      id: 101,
-      authorEmail: 'dev@example.com',
-      projectName: '프로젝트 A 기획',
-      projectCode: 'PA-2025-01',
-      projectKeyword: ['기획', '요구사항'],
-      links: ['https://github.com/org/repo-a'],
-      createdAt: '2025-08-01T09:00:00Z',
-      updatedAt: '2025-08-01T09:00:00Z',
-    },
-    {
-      id: 102,
-      authorEmail: 'ux@example.com',
-      projectName: '프로젝트 B 디자인 시안',
-      projectCode: 'PB-2025-02',
-      projectKeyword: ['디자인', '시안'],
-      links: ['https://jira.example.com/browse/DESIGN-12'],
-      createdAt: '2025-08-05T10:30:00Z',
-      updatedAt: '2025-08-05T10:30:00Z',
-    },
-    {
-      id: 103,
-      authorEmail: 'fe@example.com',
-      projectName: '프로젝트 C 개발 일정',
-      projectCode: 'PC-2025-03',
-      projectKeyword: ['개발', '일정'],
-      links: ['https://slack.com/app_redirect?channel=C123456'],
-      createdAt: '2025-08-09T12:00:00Z',
-      updatedAt: '2025-08-09T12:00:00Z',
-    },
-  ]);
+// 목록 API 실패/미설정 시 사용할 더미
+const FALLBACK_PROJECTS: ProjectDto[] = [
+  {
+    id: 1,
+    authorEmail: 'user@example.com',
+    projectName: '인포브릿지 서버 개발',
+    projectCode: 'SMG-001',
+    projectKeyword: 'InfoBridge,인포브릿지,브릿지,bridge,브리찌'
+      .split(',')
+      .map(s => s.trim()),
+    createdAt: '2025-08-09T02:35:48.042252Z',
+    updatedAt: '2025-08-09T06:45:47.825268Z',
+  },
+];
 
+export const ProjectListPage = () => {
+  const [showCreate, setShowCreate] = useState(false);
+  const [projects, setProjects] = useState<ProjectDto[]>([]);
+  const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
 
   const onCreated = ({ project }: { project: ProjectDto }) => {
     setProjects(prev => [project, ...prev]);
-    navigate(`/projects/${project.id}`);
   };
 
-  return (
-    <Page>
-      <Header>
-        <Title>Projects</Title>
-        <CreateButton onClick={() => navigate(`/projects/new`)}>
-          새 프로젝트 만들기
-        </CreateButton>
-      </Header>
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const data = await listProjects();
+        if (alive) setProjects(data);
+      } catch (e: any) {
+        if (alive) {
+          setError(
+            e?.message ||
+              '프로젝트 목록을 불러올 수 없습니다. 더미 데이터로 표시합니다.'
+          );
+          setProjects(FALLBACK_PROJECTS);
+        }
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
 
+  return (
+    <Page
+      style={{
+        gap: 16,
+        padding: 16,
+        boxSizing: 'border-box',
+      }}
+    >
+      <Navbar userName="Developer Kim" userEmail="developer@infobridge.com" />
       <Main>
-        <SectionTitle>최근 프로젝트</SectionTitle>
+        {error && (
+          <div style={{ color: '#dc2626', fontSize: 13, marginBottom: 8 }}>
+            {error}
+          </div>
+        )}
+
         <Row>
           <CreateCard
             to="#"
             onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
               e.preventDefault();
-              navigate(`/projects/new`);
+              setShowCreate(true);
             }}
           >
             <div style={{ textAlign: 'center' }}>
@@ -106,7 +115,7 @@ export const ProjectListPage = () => {
             </div>
           </CreateCard>
 
-          {projects.map(p => (
+          {(projects || []).map(p => (
             <CardBase key={p.id} to={`/projects/${p.id}`}>
               <div style={{ flex: 1 }}>
                 <CardTitle>
@@ -118,12 +127,18 @@ export const ProjectListPage = () => {
           ))}
         </Row>
 
-        {projects.length === 0 && (
+        {projects && projects.length === 0 && (
           <EmptyText>
             아직 프로젝트가 없습니다. ‘새 프로젝트 만들기’를 눌러 생성해 보세요.
           </EmptyText>
         )}
       </Main>
+      {showCreate && (
+        <CreateProjectModal
+          onClose={() => setShowCreate(false)}
+          onSuccess={onCreated}
+        />
+      )}
     </Page>
   );
 };

--- a/src/types/dto/projects.dto.ts
+++ b/src/types/dto/projects.dto.ts
@@ -4,7 +4,6 @@ export type ProjectDto = {
   projectName: string;
   projectCode: string;
   projectKeyword?: string[];
-  links?: string[];
   createdAt: string;
   updatedAt: string;
 };


### PR DESCRIPTION
#### **📝 개요 (Overview)**

이번 PR에서는 프로젝트 생성을 위한 Modal창의 UI를 구성하고 이를 통해 Projects를 생성할 경우 해당 프로젝트의 주소로 라우팅 되도록 구현하였습니다. 또한 초기화면에서 Projects의 목록을 받아오도록 구현하였습니다

---

#### **✨ 주요 변경 내용 (Key Changes)**

* **1. Modal을 구현하여 Project에 관한 정보와 링크를 입력하고 생성할 수 있습니다**
* **2. 초기페이지에서 Projects의 목록을 받아오도록 구현하였습니다**
* **3. UI를 프로젝트 페이지와 유사하게 변경하였습니다**

---

#### **스크린샷**
<img width="1840" height="1191" alt="스크린샷 2025-08-09 오후 11 43 33" src="https://github.com/user-attachments/assets/2ccc114e-0bd2-4997-bbfb-73e2d7aef992" />

<img width="1840" height="1191" alt="스크린샷 2025-08-09 오후 11 44 01" src="https://github.com/user-attachments/assets/08a50aaa-cb51-44e6-a270-61c2f4411784" />




